### PR TITLE
fix(typed-cqrs): use less collision prone type field in query

### DIFF
--- a/packages/typed-cqrs/src/command.ts
+++ b/packages/typed-cqrs/src/command.ts
@@ -1,5 +1,5 @@
 import { ICommand } from '@nestjs/cqrs';
 
 export class Command<T> implements ICommand {
-  $resultType!: T;
+  resultType$e1ca39fa!: T;
 }

--- a/packages/typed-cqrs/src/query.ts
+++ b/packages/typed-cqrs/src/query.ts
@@ -1,5 +1,5 @@
 import { IQuery } from '@nestjs/cqrs';
 
 export class Query<T> implements IQuery {
-  resultType!: T;
+  resultType$f9fbca36!: T;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/valueadd-poland/nestjs-packages/blob/master/CONTRIBUTING.md#git-guidelines
- [-] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`resultType` is likely to be used in a query.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The artificial `resultType` field will not collide, if the same name is used in a query.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
